### PR TITLE
Fix libraryTarget to work with modules in browser

### DIFF
--- a/dist/openiban.browser.js
+++ b/dist/openiban.browser.js
@@ -1,5 +1,14 @@
-window["Openiban"] =
-/******/ (function(modules) { // webpackBootstrap
+(function webpackUniversalModuleDefinition(root, factory) {
+	if(typeof exports === 'object' && typeof module === 'object')
+		module.exports = factory();
+	else if(typeof define === 'function' && define.amd)
+		define([], factory);
+	else if(typeof exports === 'object')
+		exports["Openiban"] = factory();
+	else
+		root["Openiban"] = factory();
+})(typeof self !== 'undefined' ? self : this, function() {
+return /******/ (function(modules) { // webpackBootstrap
 /******/ 	// The module cache
 /******/ 	var installedModules = {};
 /******/
@@ -6252,3 +6261,4 @@ exports.clearImmediate = (typeof self !== "undefined" && self.clearImmediate) ||
 
 /***/ })
 /******/ ]);
+});

--- a/dist/types/index.d.ts
+++ b/dist/types/index.d.ts
@@ -5,3 +5,4 @@ export interface OpenibanOptions {
     validateBankCode?: boolean;
 }
 export declare function validate(iban: string, opts?: OpenibanOptions): Promise<ValidationResult>;
+export { ValidationResult };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openiban",
-  "version": "1.0.2",
+  "version": "1.1.0",
   "description": "openiban.com client for node and the browser",
   "main": "./dist/openiban.node.js",
   "browser": "./dist/openiban.browser.js",

--- a/src/index.ts
+++ b/src/index.ts
@@ -26,3 +26,4 @@ export function validate(iban: string, opts: OpenibanOptions = defaultOptions): 
     });
 }
 
+export { ValidationResult };

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -43,7 +43,7 @@ var clientConfig = {
   },
   output: {
     library: 'Openiban',
-    libraryTarget: 'window'
+    libraryTarget: 'umd'
   },
   resolve: {
     alias: {


### PR DESCRIPTION
* At present the `OpenIban` is accessible using window object in browser, e.g:- [Banking app](https://github.com/Savedo/savedo-banking-app/blob/master/app/services/iban/iban-data.service.ts#L20).

* This PR will change it so we can import as module.

* [Webpack documentation](https://webpack.js.org/guides/author-libraries/#expose-the-library)

[Related ticket](https://jira.deposit-solutions.com/browse/SAV-616)